### PR TITLE
AT code reorganisation: wrapper generation / function lookup: snapshot

### DIFF
--- a/atintegrators/ElemPass.h
+++ b/atintegrators/ElemPass.h
@@ -1,0 +1,37 @@
+#ifndef _PyAT_ELEMPASS_H_
+#define _PyAT_ELEMPASS_H_ 1
+
+#undef __BEGIN_DECLS
+#undef __END_DECLS
+#ifdef __cplusplus
+# define __BEGIN_DECLS extern "C" {
+# define __END_DECLS }
+#else
+# define __BEGIN_DECLS /* empty */
+# define __END_DECLS /* empty */
+#endif
+
+__BEGIN_DECLS
+
+/**
+ *  Todo:
+ *   include definition of parameters of the FUNC DEC MACRO
+ */
+/*
+ * need to solve header organisation
+ */
+// #include "element_integrator_macros.h"
+#define FUNCDEFMACRO(name)			\
+    struct elem_type*  \
+    ELEM_PASS_FUNC_NAME(name)(const PyObject *ElemData, struct elem_type *Elem, double ps[], \
+              const int num_particles, const struct parameters *Param)
+#define HEADERMACRO(name) FUNCDEFMACRO(name) ;
+
+
+#undef ELEM_PASS
+#define ELEM_PASS(name, pass_name, api_identifier) HEADERMACRO(name)
+/* use it here to make forward declarations for the functions */
+#include "element_integrators.h"
+__END_DECLS
+
+#endif /* _PyAT_ELEMPASS_H_ */

--- a/atintegrators/element_integrators.h
+++ b/atintegrators/element_integrators.h
@@ -1,0 +1,28 @@
+/* no guard macros on purpose */
+/*
+ * can the marco implementations simplified by a more consistent naming
+ * of the internal functions ?
+ */
+
+ELEM_PASS(corr,  CorrectorPass, "")
+ELEM_PASS(id,    IdentityPass, "")
+ELEM_PASS(drift, DriftPass, "")
+ELEM_PASS(cav,   CavityPass, "")
+ELEM_PASS(M66,   Matrix66Pass, "")
+
+/* these below require a bit of helper init functions */
+ELEM_PASS(aper,        AperturePass, "")
+ELEM_PASS(bend,        MpolePassNoRad, "BndMPoleSymplectic4Pass")
+ELEM_PASS(bend_rad,    MpolePassRad,   "BndMPoleSymplectic4RadPass")
+ELEM_PASS(bend_exact,  MpoleE2Pass,    "BndMPoleSymplectic4E2Pass")
+ELEM_PASS(cbend,       CBendPass,      "BndStrMPoleSymplectic4Pass")
+
+ELEM_PASS(H_exact,     HamPass,      "ExactHamiltonianPass")
+
+/* these use */
+ELEM_PASS(wig,         WigPass,      "GWigSymplecticPass")
+ELEM_PASS(wig_rad,     WigPass,      "GWigSymplecticRadPass")
+ELEM_PASS(mpole,       MpolePass,    "StrMPoleSymplectic4Pass")
+ELEM_PASS(mpole_rad,   MpolePassRad, "StrMPoleSymplectic4RadPass")
+
+/* no guard macros on purpose */

--- a/atintegrators/element_integrators_macros.h
+++ b/atintegrators/element_integrators_macros.h
@@ -1,0 +1,4 @@
+#ifndef _PyAT_ELEMENT_INTEGRATOR_MACROS_H_
+#define _PyAT_ELEMENT_INTEGRATOR_MACROS_H_ 1
+#define ELEM_PASS_FUNC_NAME(name) name ## _pass
+#endif /* _PyAT_ELEMENT_INTEGRATOR_MACROS_H_ */

--- a/atintegrators/utils.h
+++ b/atintegrators/utils.h
@@ -1,0 +1,16 @@
+#ifndef _PyAT_UTILS_H_
+#define _PyAT_UTILS_H_ 1
+
+/**
+ * Todo:
+ *     unify with header in thor_scsi/python
+ */
+#define STRINGIFY(a_var) #a_var
+#define TOSTRING(a_str) STRINGIFY(a_str)
+
+
+#define DISPLAY_VAR(a_var) #a_var  " = " STRINGIFY(a_var)
+#define DISPLAY_AT() __FILE__ ":" TOSTRING(__LINE__)
+#define DISPLAY_VAR_AT(a_var)  DISPLAY_AT() " "  DISPLAY_VAR(NO_TPSA)
+
+#endif

--- a/pyat/integrator_helper.cc
+++ b/pyat/integrator_helper.cc
@@ -1,0 +1,21 @@
+#include <map>
+
+/**
+ * Todo:
+ *     Should be improved with std::mv
+ */
+#include "integrator-src/element_integrators_macros.h"
+
+#define ELEM_PASS(name, pass_name, api_identifier) \
+  lut[api_identifier] = ELEM_PASS_FUNC_NAME(name);
+
+#include "integrator-src/ElemPass.h"
+
+static std::map<std::string, track_function>  create_integrators_lookup_table(void){
+
+  std::map<std::string, track_function> lut;
+
+#include "integrator-src/element_integrators.h"
+
+}
+std::map<std::string, track_function>  integrators_lookup_table = create_integrators_lookup_table();


### PR DESCRIPTION
Work in progress

Preprocessor macros are used to define wrappers as far as feasible.
Function pointer lookup in a map.

Trying to resolve why
* at library and element library are in different files
* and if required why not pythons module mechanism is used for
  loading these files.

It seems to be that a proper implementation as python module
will simplify all further steps.